### PR TITLE
Initialize ImguiHookDx11 Instance singleton earlier

### DIFF
--- a/Reloaded.Imgui.Hook.Direct3D11/ImguiHookDx11.cs
+++ b/Reloaded.Imgui.Hook.Direct3D11/ImguiHookDx11.cs
@@ -58,10 +58,10 @@ namespace Reloaded.Imgui.Hook.Direct3D11
         {
             var presentPtr = (long)DX11Hook.DXGIVTable[(int)IDXGISwapChain.Present].FunctionPointer;
             var resizeBuffersPtr = (long)DX11Hook.DXGIVTable[(int)IDXGISwapChain.ResizeBuffers].FunctionPointer;
-
+            Instance = this;
             _presentHook = SDK.Hooks.CreateHook<DX11Hook.Present>(typeof(ImguiHookDx11), nameof(PresentImplStatic), presentPtr).Activate();
             _resizeBuffersHook = SDK.Hooks.CreateHook<DX11Hook.ResizeBuffers>(typeof(ImguiHookDx11), nameof(ResizeBuffersImplStatic), resizeBuffersPtr).Activate();
-            Instance = this;
+            
         }
         ~ImguiHookDx11()
         {


### PR DESCRIPTION
While injecting into unsuspended processes, the hook implementation(=> Instance.PresentImpl) sometimes crashed for me, because Instance was not set yet.

Moving the singleton initialisation above the hooks fixes this problem.