### PR TITLE
Fix access violation when ResizeBuffers() is called early

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Reloaded.Imgui.Hook.Direct3D11/ImguiHookDx11.cs
+++ b/Reloaded.Imgui.Hook.Direct3D11/ImguiHookDx11.cs
@@ -122,7 +122,7 @@ namespace Reloaded.Imgui.Hook.Direct3D11
             _renderTargetView?.Dispose();
             _renderTargetView = null;
             // ImGui doesn't null check this for us :(
-            if (ImGui.GetIO().BackendRendererUserData != IntPtr.Zero)
+            if (_initialized)
             {
                 ImGui.ImGuiImplDX11InvalidateDeviceObjects();
             }
@@ -130,7 +130,8 @@ namespace Reloaded.Imgui.Hook.Direct3D11
 
         private void PostResizeBuffers(IntPtr swapChainPtr)
         {
-            if (ImGui.GetIO().BackendRendererUserData != IntPtr.Zero) {
+            if (_initialized)
+            {
                 ImGui.ImGuiImplDX11CreateDeviceObjects();
                 _renderTargetView?.Dispose();
                 var swapChain = new SwapChain(swapChainPtr);


### PR DESCRIPTION
Related issue: #7 

Some games (like modern GameMaker) resize the window before the DX11 backend is initialized. ImGui [does not null check the backend data](https://github.com/ocornut/imgui/blob/aa5a6098ee24ca30b3e0a180282619777e95fc67/backends/imgui_impl_dx11.cpp#L529) in some spots, so we have to check if we've initialized before calling them. **This is an upstream ImGui issue** and this is just a workaround for it. Whether it is considered invalid behavior by them is unknown. This might also happen on DX9, but I don't have a game to test it with.

Sorry about the random whitespace changes, that was Rider being mystical and magical.